### PR TITLE
chore(deploy): 配置Redis密码为RedMoon

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -56,7 +56,7 @@ UPLOADS_HOST_PATH=/home/hrofficial/hrofficial-deploy/uploads
 # Redis 配置（默认: localhost:6379 无密码）
 # REDIS_HOST=localhost
 # REDIS_PORT=6379
-# REDIS_PASSWORD=
+# REDIS_PASSWORD=RedMoon
 
 # 阿里云 OSS 配置（不配置则使用本地文件存储）
 # ALIYUN_OSS_ENDPOINT=oss-cn-beijing.aliyuncs.com

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -166,7 +166,7 @@ wait_for_ready() {
     # 等待Redis
     echo "等待Redis就绪..."
     for i in {1..30}; do
-        if docker-compose exec -T redis redis-cli ping &> /dev/null; then
+        if docker-compose exec -T redis redis-cli -a "${REDIS_PASSWORD:-RedMoon}" ping &> /dev/null; then
             echo -e "${GREEN}✓ Redis已就绪${NC}"
             break
         fi

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -28,10 +28,12 @@ services:
     image: redis/redis-stack:latest
     container_name: hrofficial-redis
     restart: unless-stopped
+    environment:
+      - REDIS_ARGS=--requirepass RedMoon
     volumes:
       - redis-data:/data
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "redis-cli", "-a", "RedMoon", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -49,6 +51,7 @@ services:
       DB_PASSWORD: ${DB_PASSWORD}
       REDIS_HOST: redis
       REDIS_PORT: 6379
+      REDIS_PASSWORD: RedMoon
       CHATECNU_BASE_URL: ${CHATECNU_BASE_URL:-https://chat.ecnu.edu.cn/open/api}
       CHATECNU_API_KEY: ${CHATECNU_API_KEY}
       JWT_SECRET: ${JWT_SECRET}

--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,9 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.redmoon2333.Main</mainClass>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -8,6 +8,7 @@ spring:
     redis:
       host: localhost
       port: 6379
+      password: RedMoon
 
   jpa:
     show-sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,7 +37,7 @@ spring:
     redis:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
-      password: ${REDIS_PASSWORD:}
+      password: ${REDIS_PASSWORD:RedMoon}
       database: 0
       timeout: 10000ms
       lettuce:


### PR DESCRIPTION
- 在.env.example中默认启用REDIS_PASSWORD为RedMoon
- 在application.yml和application-dev.yml中配置Redis密码
- 修改docker-compose.yml为Redis容器添加密码环境变量和健康检查
- 更新deploy.sh脚本支持带密码的Redis连接检测
- 为spring-boot-maven-plugin添加mainClass配置<com.redmoon2333.Main>