### PR TITLE
feat(performance): 启用Redis缓存、添加RabbitMQ服务、优化N+1查询和冗余查询

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -38,6 +38,24 @@ services:
       timeout: 5s
       retries: 5
 
+  rabbitmq:
+    image: rabbitmq:3.12-management-alpine
+    container_name: hrofficial-rabbitmq
+    restart: unless-stopped
+    environment:
+      RABBITMQ_DEFAULT_USER: guest
+      RABBITMQ_DEFAULT_PASS: guest
+    ports:
+      - "127.0.0.1:5672:5672"
+      - "127.0.0.1:15672:15672"
+    volumes:
+      - rabbitmq-data:/var/lib/rabbitmq
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   backend:
     image: ${DOCKER_IMAGE:-redmoon2333/hrofficial-backend:latest}
     container_name: hrofficial-backend
@@ -45,7 +63,7 @@ services:
     ports:
       - "127.0.0.1:8080:8080"
     environment:
-      SPRING_PROFILES_ACTIVE: prod
+      SPRING_PROFILES_ACTIVE: prod,rabbitmq
       SPRING_DATA_REDIS_HOST: redis
       SPRING_DATA_REDIS_PORT: 6379
       SPRING_DATA_REDIS_PASSWORD: ${REDIS_PASSWORD}
@@ -73,3 +91,4 @@ services:
 volumes:
   mysql-data:
   redis-data:
+  rabbitmq-data:

--- a/src/main/java/com/redmoon2333/Main.java
+++ b/src/main/java/com/redmoon2333/Main.java
@@ -3,11 +3,13 @@ package com.redmoon2333;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @MapperScan("com.redmoon2333.mapper")
 @EnableScheduling
+@EnableCaching
 public class Main {
     public static void main(String[] args) {
         SpringApplication.run(Main.class, args);

--- a/src/main/java/com/redmoon2333/config/RabbitMQConfig.java
+++ b/src/main/java/com/redmoon2333/config/RabbitMQConfig.java
@@ -23,7 +23,7 @@ import org.springframework.context.annotation.Profile;
  * 2. 在 application.yml 中添加 rabbitmq profile
  * 3. 启动 RabbitMQ Docker 容器
  */
-@Profile("rabbitmq-disabled")  // 已禁用，改为 "rabbitmq" 可启用
+@Profile("rabbitmq")
 @Configuration
 public class RabbitMQConfig {
 

--- a/src/main/java/com/redmoon2333/config/RedisConfig.java
+++ b/src/main/java/com/redmoon2333/config/RedisConfig.java
@@ -4,19 +4,31 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.cache.RedisCacheWriter;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Redis配置类
- * 配置Redis序列化方式和模板
+ * 配置Redis序列化方式、模板和缓存管理器
  */
 @Configuration
+@EnableCaching
 public class RedisConfig {
 
     /**
@@ -28,9 +40,15 @@ public class RedisConfig {
         RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);
 
-        // 配置Jackson2JsonRedisSerializer序列化策略
-        Jackson2JsonRedisSerializer<Object> jackson2JsonRedisSerializer = 
-            new Jackson2JsonRedisSerializer<>(Object.class);
+        // 配置GenericJackson2JsonRedisSerializer序列化策略
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
+        objectMapper.activateDefaultTyping(
+            LaissezFaireSubTypeValidator.instance,
+            ObjectMapper.DefaultTyping.NON_FINAL
+        );
+        GenericJackson2JsonRedisSerializer genericJackson2JsonRedisSerializer = 
+            new GenericJackson2JsonRedisSerializer(objectMapper);
         
         // 配置序列化策略
         StringRedisSerializer stringRedisSerializer = new StringRedisSerializer();
@@ -40,8 +58,8 @@ public class RedisConfig {
         template.setHashKeySerializer(stringRedisSerializer);
         
         // value和hash value采用Jackson序列化方式
-        template.setValueSerializer(jackson2JsonRedisSerializer);
-        template.setHashValueSerializer(jackson2JsonRedisSerializer);
+        template.setValueSerializer(genericJackson2JsonRedisSerializer);
+        template.setHashValueSerializer(genericJackson2JsonRedisSerializer);
         
         template.afterPropertiesSet();
         return template;
@@ -54,5 +72,38 @@ public class RedisConfig {
     @Bean
     public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
         return new StringRedisTemplate(connectionFactory);
+    }
+
+    /**
+     * 配置Spring Cache管理器
+     * 使用Redis作为缓存后端，支持@Cacheable/@CacheEvict等注解
+     */
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
+        objectMapper.activateDefaultTyping(
+            LaissezFaireSubTypeValidator.instance,
+            ObjectMapper.DefaultTyping.NON_FINAL
+        );
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofHours(2))
+            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer))
+            .disableCachingNullValues();
+
+        Map<String, RedisCacheConfiguration> cacheConfigs = new HashMap<>();
+        cacheConfigs.put("activity", defaultConfig.entryTtl(Duration.ofHours(12)));
+        cacheConfigs.put("activity:list", defaultConfig.entryTtl(Duration.ofHours(1)));
+        cacheConfigs.put("activity:images", defaultConfig.entryTtl(Duration.ofHours(6)));
+
+        return RedisCacheManager.builder(RedisCacheWriter.nonLockingRedisCacheWriter(connectionFactory))
+            .cacheDefaults(defaultConfig)
+            .withInitialCacheConfigurations(cacheConfigs)
+            .build();
     }
 }

--- a/src/main/java/com/redmoon2333/service/ActivityService.java
+++ b/src/main/java/com/redmoon2333/service/ActivityService.java
@@ -243,22 +243,16 @@ public class ActivityService {
         }
     }
 
+    @Cacheable(value = "activity:images", key = "#activityId", unless = "#result == null || #result.isEmpty()")
     public List<ActivityImage> getImagesByActivityId(Integer activityId) {
         logger.info("获取活动的图片列表: 活动ID={}", activityId);
 
         try {
-            // 检查活动是否存在
-            Activity activity = activityMapper.selectById(activityId);
-            if (activity == null) {
-                logger.warn("尝试获取不存在的活动的图片列表: 活动ID={}", activityId);
-                throw new BusinessException(ErrorCode.ACTIVITY_NOT_FOUND);
-            }
-
             List<ActivityImage> images = activityImageMapper.findByActivityId(activityId);
             logger.info("成功获取活动图片列表: 活动ID={}, 图片数量={}", activityId, images.size());
             return images;
         } catch (BusinessException e) {
-            throw e; // 重新抛出业务异常
+            throw e;
         } catch (Exception e) {
             logger.error("获取活动图片列表时发生异常: 活动ID={}, 错误: {}", activityId, e.getMessage(), e);
             throw new BusinessException(ErrorCode.ACTIVITY_IMAGE_LIST_FAILED);

--- a/src/main/java/com/redmoon2333/service/MaterialService.java
+++ b/src/main/java/com/redmoon2333/service/MaterialService.java
@@ -24,6 +24,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 @Service
 public class MaterialService {


### PR DESCRIPTION
- 添加 @EnableCaching 和 Redis CacheManager，使 @Cacheable/@CacheEvict 生效
- 活动列表和活动图片接口添加Redis缓存，减少数据库查询
- 移除 getImagesByActivityId 中冗余的活动存在性检查
- docker-compose 添加 RabbitMQ 服务（含健康检查和管理界面）
- 更新 SPRING_PROFILES_ACTIVE 为 prod,rabbitmq
- 修复 RabbitMQConfig 和 Listener 的 @Profile 注解
- 修复 RedisConfig 序列化器类型兼容问题
- MaterialService 添加 stream.Collectors 导入