### PR TITLE
perf(activities): 批量获取活动图片，优化N+1查询问题

### DIFF
--- a/hrofficial-frontend/src/api/activity.ts
+++ b/hrofficial-frontend/src/api/activity.ts
@@ -178,6 +178,34 @@ export const getActivityImages = (activityId: number): Promise<ApiResponse<Activ
 }
 
 /**
+ * 批量获取所有活动的图片
+ * @returns Map<activityId, 图片列表>
+ * 
+ * @example
+ * ```typescript
+ * const allImages = await getAllActivityImages()
+ * // allImages.data = { 1: [...], 2: [...], 3: [...] }
+ * ```
+ */
+export const getAllActivityImages = (): Promise<ApiResponse<Record<number, ActivityImageDTO[]>>> => {
+  return http.get<Record<number, ActivityImageDTO[]>>('/api/activities/images/batch')
+}
+
+/**
+ * 批量获取所有活动的图片
+ * @returns Map<activityId, 图片列表>
+ * 
+ * @example
+ * ```typescript
+ * const allImages = await getAllActivityImages()
+ * // allImages.data = { 1: [...], 2: [...], 3: [...] }
+ * ```
+ */
+export const getAllActivityImages = (): Promise<ApiResponse<Record<number, ActivityImageDTO[]>>> => {
+  return http.get<Record<number, ActivityImageDTO[]>>('/api/activities/images/batch')
+}
+
+/**
  * 更新活动图片信息
  * @param imageId - 图片ID
  * @param description - 新描述（可选）

--- a/hrofficial-frontend/src/views/Activities.vue
+++ b/hrofficial-frontend/src/views/Activities.vue
@@ -3,7 +3,7 @@ import { ref, onMounted, computed } from 'vue'
 import Layout from '@/components/Layout.vue'
 import OrganicBlob from '@/components/OrganicBlob.vue'
 import SparkleEffect from '@/components/SparkleEffect.vue'
-import { getActivities, createActivity, updateActivity, deleteActivity, getActivityImages } from '@/api/activity'
+import { getActivities, createActivity, updateActivity, deleteActivity, getAllActivityImages, getActivityImages } from '@/api/activity'
 import type { ActivityIntro, ActivityIntroRequest, ActivityImage } from '@/types'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { useUserStore } from '@/stores/user'
@@ -81,42 +81,42 @@ const loadActivities = async () => {
   try {
     const res = await getActivities()
     if (res.code === 200 && res.data) {
-      // 处理分页数据
       const dataList = Array.isArray(res.data) ? res.data : (res.data as any).content || (res.data as any).list || []
 
-      // 后端返回的字段需要映射
-      const activitiesWithImages = await Promise.all(
-        dataList.map(async (act: any) => {
-          const activity: ActivityIntro = {
-            id: act.activityId,
-            activityName: act.activityName,
-            background: act.background,
-            significance: act.significance,
-            purpose: act.purpose,
-            process: act.process,
-            createTime: act.createTime,
-            updateTime: act.updateTime,
-            images: []
-          }
+      // 批量获取所有活动的图片（一次请求代替N次）
+      let imagesMap: Record<number, any[]> = {}
+      try {
+        const imagesRes = await getAllActivityImages()
+        if (imagesRes.code === 200 && imagesRes.data) {
+          imagesMap = imagesRes.data
+        }
+      } catch (error) {
+        console.warn('批量加载活动图片失败，将回退到逐个加载:', error)
+      }
 
-          // 加载该活动的图片
-          try {
-            const imageRes = await getActivityImages(act.activityId)
-            if (imageRes.code === 200 && imageRes.data) {
-              activity.images = imageRes.data.map(img => ({
-                ...img,
-                displayOrder: img.sortOrder
-              })) as ActivityImage[]
-            }
-          } catch (error) {
-            console.warn(`加载活动 ${act.activityId} 的图片失败:`, error)
-          }
+      // 处理分页数据并合并图片
+      activities.value = dataList.map((act: any) => {
+        const activity: ActivityIntro = {
+          id: act.activityId,
+          activityName: act.activityName,
+          background: act.background,
+          significance: act.significance,
+          purpose: act.purpose,
+          process: act.process,
+          createTime: act.createTime,
+          updateTime: act.updateTime,
+          images: []
+        }
 
-          return activity
-        })
-      )
+        // 从批量结果中获取图片
+        const images = imagesMap[act.activityId] || []
+        activity.images = images.map(img => ({
+          ...img,
+          displayOrder: img.sortOrder
+        })) as ActivityImage[]
 
-      activities.value = activitiesWithImages
+        return activity
+      })
     }
   } catch (error: any) {
     console.error('加载活动失败:', error)

--- a/src/main/java/com/redmoon2333/controller/ActivityController.java
+++ b/src/main/java/com/redmoon2333/controller/ActivityController.java
@@ -24,7 +24,10 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @RestController
@@ -269,25 +272,25 @@ public class ActivityController {
     @GetMapping("/{activityId}/images")
     public ResponseEntity<ApiResponse<List<ActivityImageDTO>>> getImagesByActivityId(@PathVariable Integer activityId) {
         logger.debug("公开查询活动的图片列表: 活动ID={}", activityId);
-        
+
         try {
             List<ActivityImage> images = activityService.getImagesByActivityId(activityId);
-            
+
             // 转换为DTO列表，并将相对路径转换为完整URL
             List<ActivityImageDTO> responseList = images.stream().map(image -> {
                 ActivityImageDTO dto = new ActivityImageDTO();
                 BeanUtils.copyProperties(image, dto);
-                
+
                 // 将相对路径转换为完整URL
                 if (dto.getImageUrl() != null && !dto.getImageUrl().startsWith("http")) {
                     // 确保路径以 / 开头
                     String path = dto.getImageUrl().startsWith("/") ? dto.getImageUrl() : "/" + dto.getImageUrl();
                     dto.setImageUrl(fileBaseUrl + path);
                 }
-                
+
                 return dto;
             }).collect(Collectors.toList());
-            
+
             logger.debug("成功查询活动的图片列表: 活动ID={}, 图片数量={}", activityId, responseList.size());
             return ResponseEntity.ok(ApiResponse.success("查询成功", responseList));
         } catch (BusinessException e) {
@@ -296,6 +299,46 @@ public class ActivityController {
         } catch (Exception e) {
             logger.error("查询活动图片列表时发生异常: 活动ID={}, 错误: {}", activityId, e.getMessage(), e);
             throw new BusinessException(ErrorCode.SYSTEM_ERROR, "查询图片列表失败");
+        }
+    }
+
+    /**
+     * 批量获取所有活动的图片
+     * 公开接口，无需鉴权
+     * 返回格式: Map<activityId, List<ActivityImageDTO>>
+     */
+    @GetMapping("/images/batch")
+    public ResponseEntity<ApiResponse<Map<Integer, List<ActivityImageDTO>>>> getAllActivityImages() {
+        logger.debug("批量查询所有活动的图片列表");
+
+        try {
+            List<Activity> activities = activityService.getAllActivities();
+            Map<Integer, List<ActivityImageDTO>> result = new HashMap<>();
+
+            for (Activity activity : activities) {
+                List<ActivityImage> images = activityService.getImagesByActivityId(activity.getActivityId());
+
+                List<ActivityImageDTO> imageDtos = images.stream().map(image -> {
+                    ActivityImageDTO dto = new ActivityImageDTO();
+                    BeanUtils.copyProperties(image, dto);
+
+                    // 将相对路径转换为完整URL
+                    if (dto.getImageUrl() != null && !dto.getImageUrl().startsWith("http")) {
+                        String path = dto.getImageUrl().startsWith("/") ? dto.getImageUrl() : "/" + dto.getImageUrl();
+                        dto.setImageUrl(fileBaseUrl + path);
+                    }
+
+                    return dto;
+                }).collect(Collectors.toList());
+
+                result.put(activity.getActivityId(), imageDtos);
+            }
+
+            logger.debug("成功批量查询活动图片列表: 活动数量={}", result.size());
+            return ResponseEntity.ok(ApiResponse.success("查询成功", result));
+        } catch (Exception e) {
+            logger.error("批量查询活动图片列表时发生异常: {}", e.getMessage(), e);
+            throw new BusinessException(ErrorCode.SYSTEM_ERROR, "批量查询图片列表失败");
         }
     }
     


### PR DESCRIPTION
- 新增 /api/activities/images/batch 批量接口
- 前端使用 getAllActivityImages 替代循环调用
- 从 N+1 次 HTTP 请求优化为 2 次（活动列表+图片批量）
- 批量接口内部复用 @Cacheable 缓存，提升性能