### PR TITLE
feat(activity): 优化活动图片管理及删除接口实现

### DIFF
--- a/hrofficial-frontend/src/api/material.ts
+++ b/hrofficial-frontend/src/api/material.ts
@@ -197,6 +197,15 @@ export const getDownloadUrl = (
   return http.get<string>(`/api/materials/download-url/${materialId}`, { expiration })
 }
 
+/**
+ * 获取资料下载链接（服务端代理，解决 OSS Referer 策略问题）
+ * @param materialId - 资料ID
+ * @returns 后端代理下载 URL
+ */
+export const getDownloadProxyUrl = (materialId: number): string => {
+  return `/api/oss/download/material/${materialId}`
+}
+
 // ============================================
 // 分类管理
 // ============================================

--- a/hrofficial-frontend/src/api/materials.ts
+++ b/hrofficial-frontend/src/api/materials.ts
@@ -131,6 +131,15 @@ export const getDownloadUrl = (
   return http.get<string>(`/api/materials/download-url/${materialId}`, { expirationSeconds })
 }
 
+/**
+ * 获取资料下载链接（服务端代理，解决 OSS Referer 策略问题）
+ * @param materialId - 资料ID
+ * @returns 后端代理下载 URL
+ */
+export const getDownloadProxyUrl = (materialId: number): string => {
+  return `/api/oss/download/material/${materialId}`
+}
+
 // ============================================
 // 分类管理
 // ============================================

--- a/hrofficial-frontend/src/router/index.ts
+++ b/hrofficial-frontend/src/router/index.ts
@@ -138,6 +138,16 @@ router.beforeEach(async (to, from, next) => {
     }
   }
   
+  // 获取用户信息后，如果 token 存在但登录状态仍为 false，说明 token 被后端撤销
+  // 此时清除登录状态并仅在非公开页面重定向
+  if (userStore.token && !userStore.isLoggedIn) {
+    userStore.logout()
+    if (!to.meta.public) {
+      ElMessage.error('登录已过期，请重新登录')
+      return next('/login')
+    }
+  }
+  
   // 现在用户信息已加载，可以安全地检查权限
   const isLoggedIn = userStore.isLoggedIn
   const isMember = userStore.isMember

--- a/hrofficial-frontend/src/stores/user.ts
+++ b/hrofficial-frontend/src/stores/user.ts
@@ -1,14 +1,58 @@
 import { defineStore } from 'pinia'
-import { ref, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
 import type { User } from '@/types'
 import { getCurrentUser } from '@/api/user'
+
+// JWT payload解码（不解签名）
+function decodeJwtToken(token: string): { exp?: number; [key: string]: any } | null {
+  try {
+    const parts = token.split('.')
+    if (parts.length !== 3) return null
+
+    const payload = parts[1]!
+      .replace(/-/g, '+')
+      .replace(/_/g, '/')
+    const padded = payload.padEnd(payload.length + (4 - (payload.length % 4)) % 4, '=')
+    const decoded = decodeURIComponent(escape(atob(padded)))
+    return JSON.parse(decoded)
+  } catch {
+    return null
+  }
+}
 
 export const useUserStore = defineStore('user', () => {
   const token = ref<string | null>(localStorage.getItem('token'))
   const userInfo = ref<User | null>(null)
   const loading = ref(false)
 
-  const isLoggedIn = computed(() => !!token.value)
+  // 从localStorage恢复时检查是否过期
+  const initialToken = token.value
+  if (initialToken) {
+    const decoded = decodeJwtToken(initialToken)
+    if (decoded && decoded.exp) {
+      const nowSeconds = Date.now() / 1000
+      if (nowSeconds >= decoded.exp) {
+        // token已过期，清除
+        localStorage.removeItem('token')
+        token.value = null
+      }
+    }
+  }
+
+  const isLoggedIn = computed(() => {
+    if (!token.value) return false
+    if (!userInfo.value) return false
+
+    const decoded = decodeJwtToken(token.value)
+    if (decoded && decoded.exp) {
+      const nowSeconds = Date.now() / 1000
+      if (nowSeconds >= decoded.exp) {
+        return false
+      }
+    }
+    return true
+  })
+
   const isMinister = computed(() => {
     if (!userInfo.value) return false
     const role = userInfo.value.roleHistory
@@ -19,13 +63,47 @@ export const useUserStore = defineStore('user', () => {
     return !!userInfo.value.roleHistory
   })
 
+  // Token过期倒计时定时器
+  let expirationTimer: ReturnType<typeof setTimeout> | null = null
+
+  // 设置Token过期倒计时
+  function setExpirationTimer(expTimestamp: number) {
+    // 清除旧定时器
+    if (expirationTimer) {
+      clearTimeout(expirationTimer)
+    }
+
+    const nowSeconds = Date.now() / 1000
+    const secondsUntilExpiration = expTimestamp - nowSeconds
+
+    if (secondsUntilExpiration > 0) {
+      // 在过期前5秒触发登出，给UI更新留出时间
+      const timeoutMs = Math.max(0, (secondsUntilExpiration - 5) * 1000)
+      expirationTimer = setTimeout(() => {
+        logout()
+        window.location.href = '/login?expired=1'
+      }, timeoutMs)
+    }
+  }
+
   // 设置Token
   function setToken(newToken: string | null) {
     token.value = newToken
     if (newToken) {
       localStorage.setItem('token', newToken)
+
+      // 解析过期时间并设置倒计时
+      const decoded = decodeJwtToken(newToken)
+      if (decoded && decoded.exp) {
+        setExpirationTimer(decoded.exp)
+      }
     } else {
       localStorage.removeItem('token')
+      // 清除倒计时定时器
+      if (expirationTimer) {
+        clearTimeout(expirationTimer)
+        expirationTimer = null
+      }
     }
   }
 
@@ -41,8 +119,8 @@ export const useUserStore = defineStore('user', () => {
       }
     } catch (error) {
       console.error('获取用户信息失败:', error)
-      // Token可能已过期
-      logout()
+      // Token可能已过期，由HTTP拦截器统一处理
+      throw error
     } finally {
       loading.value = false
     }
@@ -60,6 +138,11 @@ export const useUserStore = defineStore('user', () => {
 
   // 退出登录
   function logout() {
+    // 清除倒计时定时器
+    if (expirationTimer) {
+      clearTimeout(expirationTimer)
+      expirationTimer = null
+    }
     setToken(null)
     userInfo.value = null
   }

--- a/hrofficial-frontend/src/utils/http.ts
+++ b/hrofficial-frontend/src/utils/http.ts
@@ -1,4 +1,5 @@
 import type { ApiResponse } from '@/types'
+import { useUserStore } from '@/stores/user'
 
 // 开发环境使用代理，生产环境使用实际地址
 const API_BASE_URL = import.meta.env.PROD
@@ -56,17 +57,14 @@ class HttpClient {
 
       if (!response.ok) {
         if (response.status === 401) {
-          // Token过期或未登录，清除token并提示登录
-          const wasLoggedIn = !!localStorage.getItem('token')
-          localStorage.removeItem('token')
-          localStorage.removeItem('userInfo')
+          const userStore = useUserStore()
+          const wasLoggedIn = userStore.isLoggedIn
+          userStore.logout()
 
           if (wasLoggedIn) {
-            // 如果之前是登录状态，token过期后自动退出
             window.location.href = '/login?expired=1'
             throw new Error('登录已过期，请重新登录')
           } else {
-            // 如果未登录，提示需要登录
             throw new Error('请先登录')
           }
         }
@@ -149,6 +147,11 @@ class HttpClient {
         if (xhr.status >= 200 && xhr.status < 300) {
           const data = JSON.parse(xhr.responseText)
           resolve(data)
+        } else if (xhr.status === 401) {
+          const userStore = useUserStore()
+          userStore.logout()
+          window.location.href = '/login?expired=1'
+          reject(new Error('登录已过期，请重新登录'))
         } else {
           reject(new Error(`上传失败: ${xhr.statusText}`))
         }

--- a/hrofficial-frontend/src/views/Activities.vue
+++ b/hrofficial-frontend/src/views/Activities.vue
@@ -3,7 +3,7 @@ import { ref, onMounted, computed } from 'vue'
 import Layout from '@/components/Layout.vue'
 import OrganicBlob from '@/components/OrganicBlob.vue'
 import SparkleEffect from '@/components/SparkleEffect.vue'
-import { getActivities, createActivity, updateActivity, deleteActivity, getAllActivityImages, getActivityImages } from '@/api/activity'
+import { getActivities, createActivity, updateActivity, deleteActivity, getAllActivityImages, getActivityImages, deleteActivityImage } from '@/api/activity'
 import type { ActivityIntro, ActivityIntroRequest, ActivityImage } from '@/types'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { useUserStore } from '@/stores/user'
@@ -244,17 +244,9 @@ const handleManageImages = async (activity: ActivityIntro) => {
 // 加载活动图片
 const loadActivityImages = async (activityId: number) => {
   try {
-    const token = localStorage.getItem('token')
-    const response = await fetch(`/api/activities/${activityId}/images`, {
-      method: 'GET',
-      headers: {
-        'Authorization': `Bearer ${token}`
-      }
-    })
-
-    const result = await response.json()
-    if (result.code === 200 && result.data) {
-      activityImages.value = result.data
+    const response = await getActivityImages(activityId)
+    if (response.code === 200 && response.data) {
+      activityImages.value = response.data
     }
   } catch (error: any) {
     console.error('加载图片失败:', error)
@@ -334,22 +326,14 @@ const deleteImage = async (imageId: number) => {
       type: 'warning'
     })
 
-    const token = localStorage.getItem('token')
-    const response = await fetch(`/api/activities/images/${imageId}`, {
-      method: 'DELETE',
-      headers: {
-        'Authorization': `Bearer ${token}`
-      }
-    })
-
-    const result = await response.json()
-    if (result.code === 200) {
+    const res = await deleteActivityImage(imageId)
+    if (res.code === 200) {
       ElMessage.success('删除成功')
       if (currentActivityForImages.value) {
         await loadActivityImages(currentActivityForImages.value.id)
       }
     } else {
-      ElMessage.error(result.message || '删除失败')
+      ElMessage.error(res.message || '删除失败')
     }
   } catch (error: any) {
     if (error !== 'cancel') {

--- a/hrofficial-frontend/src/views/DailyImageManagement.vue
+++ b/hrofficial-frontend/src/views/DailyImageManagement.vue
@@ -29,13 +29,26 @@
 
       <!-- 图片列表 -->
       <div class="images-list">
+        <div v-if="selectedImages.length > 0" class="batch-actions">
+          <el-alert
+            :title="`已选中 ${selectedImages.length} 项`"
+            type="warning"
+            :closable="false"
+            show-icon
+          />
+          <el-button type="danger" :icon="Delete" @click="batchDeleteSelected">
+            批量删除
+          </el-button>
+        </div>
         <el-table
           :data="images"
           v-loading="loading"
           row-key="imageId"
           default-expand-all
           :tree-props="{ children: 'children', hasChildren: 'hasChildren' }"
+          @selection-change="handleSelectionChange"
         >
+          <el-table-column type="selection" width="55" />
           <el-table-column prop="imageId" label="ID" width="80" />
           <el-table-column prop="title" label="标题" min-width="150">
             <template #default="{ row }">
@@ -266,12 +279,12 @@ import {
   getAllImages,
   addImage,
   updateImage,
-  deleteImage as deleteImageAPI,
   updateImageStatus,
   uploadDailyImage,
   uploadDailyImageFile,
   deleteDailyImageWithFile,
   deleteDailyImageFileOnly,
+  batchDeleteImages,
   type DailyImage
 } from '@/api/dailyImage'
 import { getFullImageUrl, getFullImageUrlList } from '@/utils/image'
@@ -280,6 +293,7 @@ import { getFullImageUrl, getFullImageUrlList } from '@/utils/image'
 const loading = ref(false)
 const submitting = ref(false)
 const images = ref<DailyImage[]>([])
+const selectedImages = ref<DailyImage[]>([])
 const showAddDialog = ref(false)
 const editingImage = ref<DailyImage | null>(null)
 const formRef = ref()
@@ -587,6 +601,47 @@ const cancelReplaceImage = () => {
 onMounted(() => {
   loadImages()
 })
+
+// 处理表格选择变化
+const handleSelectionChange = (selection: DailyImage[]) => {
+  selectedImages.value = selection
+}
+
+// 批量删除选中的图片
+const batchDeleteSelected = async () => {
+  if (selectedImages.value.length === 0) {
+    ElMessage.warning('请先选择要删除的图片')
+    return
+  }
+
+  try {
+    await ElMessageBox.confirm(
+      `确定要删除选中的 ${selectedImages.value.length} 张图片吗？此操作不可恢复`,
+      '警告',
+      {
+        confirmButtonText: '确定',
+        cancelButtonText: '取消',
+        type: 'error'
+      }
+    )
+
+    const imageIds = selectedImages.value.map(img => img.imageId)
+    const res = await batchDeleteImages(imageIds)
+    if (res.code === 200) {
+      ElMessage.success('批量删除成功')
+      selectedImages.value = []
+      loadImages()
+    } else {
+      ElMessage.error(res.message || '批量删除失败')
+    }
+  } catch (error: unknown) {
+    if (error !== 'cancel') {
+      console.error('批量删除失败:', error)
+      const errMsg = error instanceof Error ? error.message : '批量删除失败'
+      ElMessage.error(errMsg)
+    }
+  }
+}
 </script>
 
 <style scoped>
@@ -700,6 +755,17 @@ onMounted(() => {
   padding: 20px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
   border: 1px solid #f3f4f6;
+}
+
+.batch-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+  padding: 12px 16px;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 8px;
 }
 
 .text-muted {

--- a/hrofficial-frontend/src/views/Materials.vue
+++ b/hrofficial-frontend/src/views/Materials.vue
@@ -251,10 +251,18 @@ const handleSubcategoryClick = async (subcategoryId: number) => {
 const handleDownload = async (material: Material) => {
   try {
     const response = await getDownloadUrl(material.materialId)
-    if (response.code === 200) {
-      window.open(response.data as string, '_blank')
-      ElMessage.success('开始下载')
-    }
+    const downloadUrl = response.data
+    const ext = material.fileType || ''
+    const filename = (material.materialName || 'download') + ext
+
+    const link = document.createElement('a')
+    link.href = downloadUrl
+    link.download = filename
+    link.target = '_blank'
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+    ElMessage.success('开始下载')
   } catch (error: any) {
     ElMessage.error(error.message || '下载失败')
   }
@@ -415,7 +423,8 @@ const handleDelete = async (material: Material) => {
       {
         confirmButtonText: '确定删除',
         cancelButtonText: '取消',
-        type: 'warning'
+        type: 'warning',
+        confirmButtonClass: 'el-button--danger'
       }
     )
     

--- a/hrofficial-frontend/src/views/PastActivities.vue
+++ b/hrofficial-frontend/src/views/PastActivities.vue
@@ -227,13 +227,16 @@ const handleDelete = async (activity: Activity, event: Event) => {
         type: 'warning'
       }
     )
+    loading.value = true
     await deletePastActivity(activity.id)
     ElMessage.success('删除成功')
-    fetchActivities()
+    await fetchActivities()
   } catch (error: any) {
     if (error !== 'cancel') {
       ElMessage.error(error.message || '删除失败')
     }
+  } finally {
+    loading.value = false
   }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,9 @@
 
     <properties>
         <java.version>17</java.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
         <spring-ai.version>1.0.0</spring-ai.version>
     </properties>
     

--- a/src/main/java/com/redmoon2333/config/MyMetaObjectHandler.java
+++ b/src/main/java/com/redmoon2333/config/MyMetaObjectHandler.java
@@ -17,6 +17,7 @@ public class MyMetaObjectHandler implements MetaObjectHandler {
     public void insertFill(MetaObject metaObject) {
         this.strictInsertFill(metaObject, "createTime", LocalDateTime.class, LocalDateTime.now());
         this.strictInsertFill(metaObject, "updateTime", LocalDateTime.class, LocalDateTime.now());
+        this.strictInsertFill(metaObject, "uploadTime", LocalDateTime.class, LocalDateTime.now());
     }
 
     @Override

--- a/src/main/java/com/redmoon2333/controller/DailyImageController.java
+++ b/src/main/java/com/redmoon2333/controller/DailyImageController.java
@@ -367,7 +367,7 @@ public class DailyImageController {
     public ApiResponse<Void> deleteImageWithFile(@PathVariable Integer id) {
         logger.info("删除图片及本地文件，ID: {}", id);
         try {
-            dailyImageService.deleteImageWithFile(id);
+            dailyImageService.deleteImage(id);
             return ApiResponse.success(null);
         } catch (IllegalArgumentException e) {
             return ApiResponse.error(e.getMessage(), 400);

--- a/src/main/java/com/redmoon2333/controller/OssController.java
+++ b/src/main/java/com/redmoon2333/controller/OssController.java
@@ -1,16 +1,27 @@
 package com.redmoon2333.controller;
 
+import com.redmoon2333.annotation.RequireMemberRole;
 import com.redmoon2333.dto.ApiResponse;
 import com.redmoon2333.dto.PresignedUrlRequest;
 import com.redmoon2333.dto.PresignedUrlResponse;
+import com.redmoon2333.entity.Material;
 import com.redmoon2333.service.ActivityService;
 import com.redmoon2333.service.MaterialService;
 import com.redmoon2333.util.OssUtil;
+import com.aliyun.oss.model.OSSObject;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 @RestController
 @RequestMapping("/api/oss")
@@ -32,6 +43,7 @@ public class OssController {
      * @param request 包含文件路径和过期时间的请求
      * @return 预签名URL响应
      */
+    @RequireMemberRole("生成预签名URL")
     @PostMapping("/presigned-url")
     public ApiResponse<PresignedUrlResponse> generatePresignedUrl(@Valid @RequestBody PresignedUrlRequest request) {
         logger.info("收到生成预签名URL请求: 文件路径={}, 过期时间={}秒", request.getFilePath(), request.getExpirationSeconds());
@@ -62,6 +74,7 @@ public class OssController {
      * @param expirationSeconds 过期时间（秒）
      * @return 预签名URL响应
      */
+    @RequireMemberRole("获取资料预签名URL")
     @GetMapping("/presigned-url/material/{materialId}")
     public ApiResponse<PresignedUrlResponse> generatePresignedUrlForMaterial(
             @PathVariable Integer materialId,
@@ -107,6 +120,7 @@ public class OssController {
      * @param expirationSeconds 过期时间（秒）
      * @return 预签名URL响应
      */
+    @RequireMemberRole("获取活动图片预签名URL")
     @GetMapping("/presigned-url/activity-image/{imageId}")
     public ApiResponse<PresignedUrlResponse> generatePresignedUrlForActivityImage(
             @PathVariable Integer imageId,
@@ -147,6 +161,89 @@ public class OssController {
     }
     
     /**
+     * 根据资料ID直接下载文件（服务端代理，使用 OSS SDK 绕过浏览器 Origin/Referer 策略）
+     * 原理: 浏览器 Origin 头触发 OSS Referer 拦截，服务端通过 SDK 直连 OSS 无此问题
+     * @param materialId 资料ID
+     * @param response HTTP 响应
+     */
+    @RequireMemberRole("下载资料")
+    @GetMapping("/download/material/{materialId}")
+    public void downloadMaterial(@PathVariable Integer materialId, HttpServletResponse response) {
+        logger.info("收到资料下载请求: materialId={}", materialId);
+
+        OSSObject ossObject = null;
+        try {
+            Material material = materialService.getMaterialForDownload(materialId);
+
+            String fileUrl = material.getFileUrl();
+            if (fileUrl == null || fileUrl.isEmpty()) {
+                response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+                response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                response.getWriter().write("{\"message\":\"未找到指定的资料文件\"}");
+                return;
+            }
+
+            String filePath = extractFilePathFromUrl(fileUrl);
+            if (filePath == null || filePath.isEmpty()) {
+                logger.error("无法从 URL 中提取文件路径: {}", fileUrl);
+                response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                response.getWriter().write("{\"message\":\"文件路径解析失败\"}");
+                return;
+            }
+
+            ossObject = ossUtil.getFileStream(filePath);
+
+            String contentType = ossObject.getObjectMetadata().getContentType();
+            long contentLength = ossObject.getObjectMetadata().getContentLength();
+
+            String downloadFilename = material.getMaterialName();
+            String fileType = material.getFileType();
+            if (fileType != null && !fileType.isEmpty() && !downloadFilename.endsWith(fileType)) {
+                downloadFilename = downloadFilename + fileType;
+            }
+
+            String encodedFilename = URLEncoder.encode(downloadFilename, StandardCharsets.UTF_8)
+                    .replace("+", "%20");
+
+            response.setContentType(contentType != null ? contentType : "application/octet-stream");
+            response.setContentLengthLong(contentLength);
+            response.setHeader(HttpHeaders.CONTENT_DISPOSITION,
+                    "attachment; filename=\"" + encodedFilename + "\"; filename*=UTF-8''" + encodedFilename);
+
+            try (InputStream in = ossObject.getObjectContent();
+                 OutputStream out = response.getOutputStream()) {
+                byte[] buffer = new byte[8192];
+                int len;
+                while ((len = in.read(buffer)) != -1) {
+                    out.write(buffer, 0, len);
+                }
+                out.flush();
+            }
+
+            materialService.incrementDownloadCount(materialId);
+            logger.info("资料下载完成: materialId={}, 文件名={}", materialId, downloadFilename);
+        } catch (Exception e) {
+            logger.error("资料下载失败: materialId={}", materialId, e);
+            try {
+                response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                response.getWriter().write("{\"message\":\"下载失败: " + e.getMessage() + "\"}");
+            } catch (Exception ex) {
+                logger.error("写入错误响应失败", ex);
+            }
+        } finally {
+            if (ossObject != null) {
+                try {
+                    ossObject.close();
+                } catch (Exception e) {
+                    logger.warn("关闭 OSSObject 失败", e);
+                }
+            }
+        }
+    }
+
+    /**
      * 从完整URL中提取OSS文件路径
      * @param fileUrl 完整的文件URL
      * @return 文件路径
@@ -155,32 +252,25 @@ public class OssController {
         if (fileUrl == null || fileUrl.isEmpty()) {
             return null;
         }
-        
-        // 处理自定义域名的情况
-        // 例如: https://oss.example.com/path/to/file.pdf -> path/to/file.pdf
-        int lastSlashIndex = fileUrl.lastIndexOf("/");
-        if (lastSlashIndex >= 0 && lastSlashIndex < fileUrl.length() - 1) {
-            return fileUrl.substring(lastSlashIndex + 1);
-        }
-        
+
         // 处理标准OSS URL的情况
         // 例如: https://bucket-name.oss-cn-hangzhou.aliyuncs.com/path/to/file.pdf -> path/to/file.pdf
-        int thirdSlashIndex = -1;
-        int slashCount = 0;
-        for (int i = 0; i < fileUrl.length(); i++) {
-            if (fileUrl.charAt(i) == '/') {
-                slashCount++;
-                if (slashCount == 3) {
-                    thirdSlashIndex = i;
-                    break;
-                }
+        // 跳过协议部分 (https:// 或 http://)
+        int protocolEndIndex = fileUrl.indexOf("://");
+        if (protocolEndIndex >= 0) {
+            int pathStartIndex = fileUrl.indexOf('/', protocolEndIndex + 3);
+            if (pathStartIndex >= 0 && pathStartIndex < fileUrl.length() - 1) {
+                return fileUrl.substring(pathStartIndex + 1);
             }
         }
-        
-        if (thirdSlashIndex >= 0 && thirdSlashIndex < fileUrl.length() - 1) {
-            return fileUrl.substring(thirdSlashIndex + 1);
+
+        // 如果没有协议前缀，查找第一个斜杠
+        int firstSlashIndex = fileUrl.indexOf('/');
+        if (firstSlashIndex >= 0 && firstSlashIndex < fileUrl.length() - 1) {
+            return fileUrl.substring(firstSlashIndex + 1);
         }
-        
+
+        // 如果URL中没有路径，返回原始URL
         return fileUrl;
     }
 }

--- a/src/main/java/com/redmoon2333/controller/UserController.java
+++ b/src/main/java/com/redmoon2333/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.redmoon2333.controller;
 
+import com.redmoon2333.annotation.RequireMinisterRole;
 import com.redmoon2333.dto.ActivationCodeResponse;
 import com.redmoon2333.dto.ActivationCodeListResponse;
 import com.redmoon2333.dto.ActivationCodeStatsResponse;
@@ -40,44 +41,6 @@ public class UserController {
     
     @Autowired(required = false)
     private RedisMemoryCleanupTask redisMemoryCleanupTask;
-    
-    /**
-     * 调试接口：获取所有用户信息
-     * 用于排查数据库数据问题
-     * 
-     * @return 所有用户的详细信息
-     */
-    @GetMapping("/debug/all")
-    public ApiResponse<?> getAllUsersDebug() {
-        try {
-            logger.info("收到调试请求：获取所有用户信息");
-            
-            // 获取用户总数
-            int userCount = userService.getUserCount();
-            logger.info("数据库中用户总数: {}", userCount);
-            
-            // 获取所有用户详细信息
-            List<User> allUsers = userService.getAllUsersDebug();
-            logger.info("实际查询到的用户数: {}", allUsers.size());
-            
-            // 输出每个用户的详细信息
-            for (com.redmoon2333.entity.User user : allUsers) {
-                logger.info("用户详情 - ID: {}, 用户名: {}, 姓名: {}, 角色历史: '{}'", 
-                    user.getUserId(), user.getUsername(), user.getName(), user.getRoleHistory());
-            }
-            
-            Map<String, Object> debugInfo = new HashMap<>();
-            debugInfo.put("totalCount", userCount);
-            debugInfo.put("actualUsers", allUsers);
-            debugInfo.put("usersWithRoleHistory", 
-                allUsers.stream().filter(u -> u.getRoleHistory() != null && !u.getRoleHistory().trim().isEmpty()).count());
-            
-            return ApiResponse.success("调试信息获取成功", debugInfo);
-        } catch (Exception e) {
-            logger.error("获取调试信息时发生异常", e);
-            return ApiResponse.error("获取调试信息失败: " + e.getMessage(), 500);
-        }
-    }
 
 
     /**
@@ -217,6 +180,7 @@ public class UserController {
      * 
      * @return 清理结果
      */
+    @RequireMinisterRole("清理Redis内存")
     @PostMapping("/cleanup-memory")
     public ApiResponse<Map<String, Object>> cleanupRedisMemory() {
         try {

--- a/src/main/java/com/redmoon2333/exception/BusinessException.java
+++ b/src/main/java/com/redmoon2333/exception/BusinessException.java
@@ -13,6 +13,11 @@ public class BusinessException extends RuntimeException {
         this.errorCode = errorCode;
     }
     
+    public BusinessException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
+    
     public BusinessException(ErrorCode errorCode, String message, Throwable cause) {
         super(message, cause);
         this.errorCode = errorCode;

--- a/src/main/java/com/redmoon2333/exception/ErrorCode.java
+++ b/src/main/java/com/redmoon2333/exception/ErrorCode.java
@@ -57,6 +57,9 @@ public enum ErrorCode {
     INVALID_REQUEST_PARAMETER(4001, "请求参数不正确"),
     VALIDATION_FAILED(4002, "数据验证失败"),
     
+    // 冲突相关错误 4100-4199
+    CONFLICT(4101, "资源冲突"),
+    
     // 系统错误 5000-5999
     SYSTEM_ERROR(5000, "系统内部错误");
     

--- a/src/main/java/com/redmoon2333/service/ActivityService.java
+++ b/src/main/java/com/redmoon2333/service/ActivityService.java
@@ -12,9 +12,12 @@ import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -38,6 +41,20 @@ public class ActivityService {
 
     @Autowired
     private LocalFileUtil localFileUtil;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    /**
+     * 直接清除活动图片缓存（不依赖 AOP，避免自调用陷阱）
+     */
+    private void evictActivityImagesCacheDirectly(Integer activityId) {
+        Cache cache = cacheManager.getCache("activity:images");
+        if (cache != null) {
+            cache.evict(activityId);
+            logger.info("已直接清除活动图片缓存: activityId={}", activityId);
+        }
+    }
 
     // @DistributedLock(key = "'activity:create:' + #activity.activityName", waitTime = 5, leaseTime = 30)
     @CacheEvict(value = "activity:list", allEntries = true)
@@ -126,7 +143,8 @@ public class ActivityService {
         }
     }
 
-    @CacheEvict(value = {"activity", "activity:list"}, allEntries = true)
+    @CacheEvict(value = {"activity", "activity:list", "activity:images"}, allEntries = true)
+    @Transactional(rollbackFor = Exception.class)
     public void deleteActivity(Integer activityId) {
         logger.info("开始删除活动: ID={}", activityId);
 
@@ -222,10 +240,18 @@ public class ActivityService {
     }
 
     @CacheEvict(value = "activity:images", key = "#activityId")
+    @Transactional(rollbackFor = Exception.class)
     public void deleteActivityImagesByActivityId(Integer activityId) {
         logger.info("删除活动的所有图片: 活动ID={}", activityId);
 
         try {
+            // 校验活动是否存在
+            Activity activity = activityMapper.selectById(activityId);
+            if (activity == null) {
+                logger.warn("尝试删除不存在的活动的图片: ID={}", activityId);
+                throw new BusinessException(ErrorCode.ACTIVITY_NOT_FOUND);
+            }
+
             List<ActivityImage> images = activityImageMapper.findByActivityId(activityId);
             logger.info("找到{}张图片需要删除", images.size());
 
@@ -284,8 +310,8 @@ public class ActivityService {
             int result = activityImageMapper.updateById(existingImage);
 
             if (result > 0) {
-                // 清除缓存
-                evictActivityImagesCache(activityId);
+                // 直接清除缓存（不依赖 AOP，避免自调用陷阱）
+                evictActivityImagesCacheDirectly(activityId);
                 logger.info("活动图片更新成功：图片 ID={}", imageId);
                 return existingImage;
             } else {
@@ -300,6 +326,7 @@ public class ActivityService {
         }
     }
 
+    @Transactional(rollbackFor = Exception.class)
     public void deleteActivityImage(Integer imageId) {
         logger.info("删除活动图片: 图片ID={}", imageId);
 
@@ -314,21 +341,20 @@ public class ActivityService {
             // 清除缓存（在删除前清除）
             Integer activityId = existingImage.getActivityId();
 
-            // 从本地服务器删除图片文件
-            String imageUrl = existingImage.getImageUrl();
-
-            try {
-                localFileUtil.deleteFile(imageUrl);
-            } catch (Exception e) {
-                logger.warn("删除本地文件失败: {}", imageUrl, e);
-            }
-
-            // 删除数据库记录
+            // 从数据库删除记录（优先）
             int result = activityImageMapper.deleteById(imageId);
 
             if (result > 0) {
-                // 清除图片缓存
-                evictActivityImagesCache(activityId);
+                // 数据库删除成功后，再删除物理文件
+                String imageUrl = existingImage.getImageUrl();
+                try {
+                    localFileUtil.deleteFile(imageUrl);
+                } catch (Exception e) {
+                    logger.warn("删除本地文件失败: {}", imageUrl, e);
+                }
+
+                // 直接清除图片缓存（不依赖 AOP，避免自调用陷阱）
+                evictActivityImagesCacheDirectly(activityId);
                 logger.info("活动图片删除成功: 图片ID={}", imageId);
             } else {
                 logger.error("活动图片删除失败: 图片ID={}", imageId);
@@ -340,11 +366,6 @@ public class ActivityService {
             logger.error("删除活动图片时发生异常: 图片ID={}, 错误: {}", imageId, e.getMessage(), e);
             throw new BusinessException(ErrorCode.ACTIVITY_IMAGE_DELETE_FAILED);
         }
-    }
-
-    @CacheEvict(value = "activity:images", key = "#activityId")
-    public void evictActivityImagesCache(Integer activityId) {
-        // 仅用于清除活动图片缓存
     }
 
     public String getImageUrlById(Integer imageId) {

--- a/src/main/java/com/redmoon2333/service/AuthService.java
+++ b/src/main/java/com/redmoon2333/service/AuthService.java
@@ -30,7 +30,6 @@ import java.util.Objects;
  * 提供用户认证相关服务，包括登录、注册、生成激活码和获取用户信息
  */
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class AuthService {
 
@@ -86,6 +85,7 @@ public class AuthService {
      * @return 注册的用户信息
      * @throws BusinessException 注册失败时抛出异常
      */
+    @Transactional(rollbackFor = Exception.class)
     public User register(RegisterRequest registerRequest) {
         // 验证密码确认
         if (!registerRequest.getPassword().equals(registerRequest.getConfirmPassword())) {
@@ -175,6 +175,7 @@ public class AuthService {
      * @return 生成的激活码
      * @throws BusinessException 权限不足或令牌无效时抛出异常
      */
+    @Transactional(rollbackFor = Exception.class)
     public ActivationCode generateActivationCode(String token, int expireDays) {
         // 验证令牌
         if (!jwtUtil.validateToken(token)) {

--- a/src/main/java/com/redmoon2333/service/DailyImageService.java
+++ b/src/main/java/com/redmoon2333/service/DailyImageService.java
@@ -118,27 +118,79 @@ public class DailyImageService {
 
     /**
      * 删除图片
+     * 先校验图片存在性，再删除本地文件，最后删除数据库记录
      *
      * @param imageId 图片ID
      */
     @Transactional(rollbackFor = Exception.class)
     public void deleteImage(Integer imageId) {
-        logger.info("删除图片，ID: {}", imageId);
+        logger.info("删除图片及本地文件，ID: {}", imageId);
+
+        // 1. 查询图片信息并校验存在性
+        DailyImage image = dailyImageMapper.selectById(imageId);
+        if (image == null) {
+            throw new IllegalArgumentException("图片不存在，ID: " + imageId);
+        }
+
+        // 2. 删除本地文件
+        String imageUrl = image.getImageUrl();
+        if (imageUrl != null && !imageUrl.isEmpty()) {
+            try {
+                localFileUtil.deleteFile(imageUrl);
+                logger.info("本地文件删除成功: {}", imageUrl);
+            } catch (Exception e) {
+                logger.warn("删除本地文件失败: {}", imageUrl, e);
+                // 继续删除数据库记录，不阻断流程
+            }
+        }
+
+        // 3. 删除数据库记录
         dailyImageMapper.deleteById(imageId);
+        logger.info("图片记录删除成功，ID: {}", imageId);
     }
 
     /**
      * 批量删除图片
+     * 先批量查询图片信息，再批量删除本地文件，最后批量删除数据库记录
      *
      * @param imageIds 图片ID列表
      */
     @Transactional(rollbackFor = Exception.class)
     public void batchDeleteImages(List<Integer> imageIds) {
         if (imageIds == null || imageIds.isEmpty()) {
-            return;
+            throw new IllegalArgumentException("图片ID列表不能为空");
         }
-        logger.info("批量删除图片，数量: {}", imageIds.size());
+
+        logger.info("批量删除图片及本地文件，数量: {}", imageIds.size());
+
+        // 1. 批量查询图片信息
+        List<DailyImage> images = dailyImageMapper.selectBatchIds(imageIds);
+        if (images.isEmpty()) {
+            throw new IllegalArgumentException("所有图片均不存在");
+        }
+
+        // 2. 批量删除本地文件
+        for (DailyImage image : images) {
+            String imageUrl = image.getImageUrl();
+            if (imageUrl != null && !imageUrl.isEmpty()) {
+                try {
+                    localFileUtil.deleteFile(imageUrl);
+                    logger.info("本地文件删除成功: {}", imageUrl);
+                } catch (Exception e) {
+                    logger.warn("删除本地文件失败: {}", imageUrl, e);
+                    // 继续处理其他文件
+                }
+            }
+        }
+
+        // 3. 批量删除数据库记录
         dailyImageMapper.batchDelete(imageIds);
+
+        // 4. 校验实际删除数量
+        if (images.size() < imageIds.size()) {
+            logger.warn("部分图片不存在，预期删除: {}, 实际删除: {}", imageIds.size(), images.size());
+        }
+        logger.info("批量删除完成，实际删除数量: {}", images.size());
     }
 
     /**
@@ -230,38 +282,6 @@ public class DailyImageService {
 
         logger.info("日常活动图片文件上传成功: URL={}", imageUrl);
         return imageUrl;
-    }
-
-    /**
-     * 删除图片并删除本地文件
-     *
-     * @param imageId 图片ID
-     */
-    @Transactional(rollbackFor = Exception.class)
-    public void deleteImageWithFile(Integer imageId) {
-        logger.info("删除图片及本地文件，ID: {}", imageId);
-
-        // 1. 获取图片信息
-        DailyImage image = dailyImageMapper.selectById(imageId);
-        if (image == null) {
-            throw new IllegalArgumentException("图片不存在，ID: " + imageId);
-        }
-
-        // 2. 删除本地文件
-        String imageUrl = image.getImageUrl();
-        if (imageUrl != null && !imageUrl.isEmpty()) {
-            try {
-                localFileUtil.deleteFile(imageUrl);
-                logger.info("本地文件删除成功: {}", imageUrl);
-            } catch (Exception e) {
-                logger.warn("删除本地文件失败: {}", imageUrl, e);
-                // 继续删除数据库记录，不阻断流程
-            }
-        }
-
-        // 3. 删除数据库记录
-        dailyImageMapper.deleteById(imageId);
-        logger.info("图片记录删除成功，ID: {}", imageId);
     }
 
     /**

--- a/src/main/java/com/redmoon2333/service/MaterialService.java
+++ b/src/main/java/com/redmoon2333/service/MaterialService.java
@@ -67,7 +67,7 @@ public class MaterialService {
      * @param description 资料描述
      * @return 保存的资料对象
      */
-    @Transactional
+    @Transactional(rollbackFor = Exception.class)
     public Material uploadMaterial(MultipartFile file, Integer categoryId, Integer subcategoryId, 
                                  String materialName, String description) throws IOException {
         try {
@@ -112,7 +112,7 @@ public class MaterialService {
             return material;
         } catch (Exception e) {
             logger.error("文件上传失败: {}", e.getMessage(), e);
-            throw new BusinessException(ErrorCode.FILE_UPLOAD_ERROR);
+            throw new BusinessException(ErrorCode.FILE_UPLOAD_ERROR, e);
         }
     }
 
@@ -126,7 +126,7 @@ public class MaterialService {
      * @param uploaderId 上传者ID
      * @return 保存的资料对象
      */
-    @Transactional
+    @Transactional(rollbackFor = Exception.class)
     public Material uploadMaterial(Integer categoryId, Integer subcategoryId, 
                                   String materialName, String description, 
                                   MultipartFile file, Integer uploaderId) throws IOException {
@@ -222,7 +222,7 @@ public class MaterialService {
         Material material = materialMapper.selectById(materialId);
         if (material == null) {
             logger.warn("未找到指定资料：materialId={}", materialId);
-            throw new RuntimeException("指定的资料不存在");
+            throw new BusinessException(ErrorCode.NOT_FOUND, "指定的资料不存在");
         }
         logger.info("成功获取资料详情：materialId={}", materialId);
         return material;
@@ -248,7 +248,7 @@ public class MaterialService {
      * 增加资料下载次数
      * @param materialId 资料ID
      */
-    private void incrementDownloadCount(Integer materialId) {
+    public void incrementDownloadCount(Integer materialId) {
         logger.info("统计资料下载次数: materialId={}", materialId);
 
         Material material = materialMapper.selectById(materialId);
@@ -267,7 +267,8 @@ public class MaterialService {
      * @param sortOrder 排序
      * @return 创建的分类对象
      */
-    @Transactional
+    @Transactional(rollbackFor = Exception.class)
+    @CacheEvict(value = "material:categories", allEntries = true)
     public MaterialCategory createCategory(String categoryName, Integer sortOrder) {
         logger.info("创建分类: categoryName={}", categoryName);
         
@@ -278,7 +279,7 @@ public class MaterialService {
         MaterialCategory existingCategory = categoryMapper.findByName(categoryName);
         if (existingCategory != null) {
             logger.warn("分类已存在: categoryName={}", categoryName);
-            throw new RuntimeException("该分类已存在");
+            throw new BusinessException(ErrorCode.CONFLICT, "该分类已存在");
         }
 
         MaterialCategory category = new MaterialCategory(categoryName, sortOrder);
@@ -295,7 +296,8 @@ public class MaterialService {
      * @param sortOrder 排序
      * @return 创建的子分类对象
      */
-    @Transactional
+    @Transactional(rollbackFor = Exception.class)
+    @CacheEvict(value = {"material:categories", "material:subcategories"}, allEntries = true)
     public MaterialSubcategory createSubcategory(Integer categoryId, String subcategoryName, Integer sortOrder) {
         logger.info("创建子分类: categoryId={}, subcategoryName={}", categoryId, subcategoryName);
         
@@ -306,14 +308,14 @@ public class MaterialService {
         MaterialCategory category = categoryMapper.selectById(categoryId);
         if (category == null) {
             logger.warn("指定的分类不存在: categoryId={}", categoryId);
-            throw new RuntimeException("指定的分类不存在");
+            throw new BusinessException(ErrorCode.NOT_FOUND, "指定的分类不存在");
         }
 
         // 检查子分类是否已存在
         MaterialSubcategory existingSubcategory = subcategoryMapper.findByNameAndCategoryId(subcategoryName, categoryId);
         if (existingSubcategory != null) {
             logger.warn("该分类下已存在同名子分类: categoryId={}, subcategoryName={}", categoryId, subcategoryName);
-            throw new RuntimeException("该分类下已存在同名子分类");
+            throw new BusinessException(ErrorCode.CONFLICT, "该分类下已存在同名子分类");
         }
 
         MaterialSubcategory subcategory = new MaterialSubcategory(categoryId, subcategoryName, sortOrder);
@@ -412,7 +414,7 @@ public class MaterialService {
      * @param description 描述
      * @return 更新后的资料对象
      */
-    @Transactional
+    @Transactional(rollbackFor = Exception.class)
     public Material updateMaterial(Integer materialId, Integer categoryId, Integer subcategoryId, 
                                    String materialName, String description) {
         logger.info("更新资料信息: materialId={}", materialId);
@@ -423,7 +425,7 @@ public class MaterialService {
         Material material = materialMapper.selectById(materialId);
         if (material == null) {
             logger.warn("未找到指定资料: materialId={}", materialId);
-            throw new RuntimeException("指定的资料不存在");
+            throw new BusinessException(ErrorCode.NOT_FOUND, "指定的资料不存在");
         }
 
 material.setCategoryId(categoryId);
@@ -440,7 +442,8 @@ material.setCategoryId(categoryId);
      * 删除资料
      * @param materialId 资料 ID
      */
-    @Transactional
+    @Transactional(rollbackFor = Exception.class)
+    @CacheEvict(value = {"material:categories", "material:subcategories"}, allEntries = true)
     public void deleteMaterial(Integer materialId) {
         logger.info("删除资料: materialId={}", materialId);
         
@@ -450,7 +453,7 @@ material.setCategoryId(categoryId);
         Material material = materialMapper.selectById(materialId);
         if (material == null) {
             logger.warn("未找到指定资料: materialId={}", materialId);
-            throw new RuntimeException("指定的资料不存在");
+            throw new BusinessException(ErrorCode.NOT_FOUND, "指定的资料不存在");
         }
 
         // 删除文件
@@ -471,7 +474,6 @@ material.setCategoryId(categoryId);
      * @param expirationSeconds 过期时间（秒），默认1小时
      * @return 预签名URL
      */
-    @Transactional
     public String generateDownloadUrl(Integer materialId, Long expirationSeconds) {
         logger.info("为资料生成预签名URL: materialId={}, 过期时间={}s", materialId, expirationSeconds);
         
@@ -485,6 +487,8 @@ material.setCategoryId(categoryId);
         String cachedUrl = stringRedisTemplate.opsForValue().get(cacheKey);
         if (cachedUrl != null && !cachedUrl.isEmpty()) {
             logger.info("从Redis缓存中获取预签名URL: materialId={}", materialId);
+            // 缓存命中时也统计下载次数
+            incrementDownloadCount(materialId);
             return cachedUrl;
         }
         
@@ -524,6 +528,22 @@ material.setCategoryId(categoryId);
     }
     
     /**
+     * 根据资料ID获取完整的资料对象（供下载代理使用，不重复鉴权）
+     * @param materialId 资料ID
+     * @return 资料对象
+     */
+    public Material getMaterialForDownload(Integer materialId) {
+        if (materialId == null) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST_PARAMETER, "资料ID不能为空");
+        }
+        Material material = materialMapper.selectById(materialId);
+        if (material == null) {
+            throw new BusinessException(ErrorCode.NOT_FOUND, "未找到指定的资料");
+        }
+        return material;
+    }
+
+    /**
      * 获取资料文件URL（保留原有接口兼容性）
      * @param materialId 资料ID
      * @return 文件URL
@@ -548,7 +568,7 @@ material.setCategoryId(categoryId);
      * @param sortOrder 排序
      * @return 更新后的分类对象
      */
-    @Transactional
+    @Transactional(rollbackFor = Exception.class)
     @CacheEvict(value = "material:categories", allEntries = true)
     public MaterialCategory updateCategory(Integer categoryId, String categoryName, Integer sortOrder) {
         logger.info("更新分类信息: categoryId={}, categoryName={}", categoryId, categoryName);
@@ -560,14 +580,14 @@ material.setCategoryId(categoryId);
         MaterialCategory category = categoryMapper.selectById(categoryId);
         if (category == null) {
             logger.warn("未找到指定分类: categoryId={}", categoryId);
-            throw new RuntimeException("指定的分类不存在");
+            throw new BusinessException(ErrorCode.NOT_FOUND, "指定的分类不存在");
         }
         
         // 检查名称是否与其他分类重复
         MaterialCategory existingCategory = categoryMapper.findByName(categoryName);
         if (existingCategory != null && !existingCategory.getCategoryId().equals(categoryId)) {
             logger.warn("分类名称已存在: categoryName={}", categoryName);
-            throw new RuntimeException("该分类名称已存在");
+            throw new BusinessException(ErrorCode.CONFLICT, "该分类名称已存在");
         }
         
         category.setCategoryName(categoryName);
@@ -585,7 +605,7 @@ material.setCategoryId(categoryId);
      * @param sortOrder 排序
      * @return 更新后的子分类对象
      */
-    @Transactional
+    @Transactional(rollbackFor = Exception.class)
     @CacheEvict(value = "material:subcategories", allEntries = true)
     public MaterialSubcategory updateSubcategory(Integer subcategoryId, String subcategoryName, Integer sortOrder) {
         logger.info("更新子分类信息: subcategoryId={}, subcategoryName={}", subcategoryId, subcategoryName);
@@ -597,7 +617,7 @@ material.setCategoryId(categoryId);
         MaterialSubcategory subcategory = subcategoryMapper.selectById(subcategoryId);
         if (subcategory == null) {
             logger.warn("未找到指定子分类: subcategoryId={}", subcategoryId);
-            throw new RuntimeException("指定的子分类不存在");
+            throw new BusinessException(ErrorCode.NOT_FOUND, "指定的子分类不存在");
         }
 
         // 检查名称是否与同分类下的其他子分类重复
@@ -606,7 +626,7 @@ material.setCategoryId(categoryId);
         if (existingSubcategory != null && !existingSubcategory.getSubcategoryId().equals(subcategoryId)) {
             logger.warn("该分类下已存在同名子分类: categoryId={}, subcategoryName={}",
                 subcategory.getCategoryId(), subcategoryName);
-            throw new RuntimeException("该分类下已存在同名子分类");
+            throw new BusinessException(ErrorCode.CONFLICT, "该分类下已存在同名子分类");
         }
 
         subcategory.setSubcategoryName(subcategoryName);
@@ -622,7 +642,7 @@ material.setCategoryId(categoryId);
      * 使用MyBatis-Plus的deleteById方法
      * @param categoryId 分类ID
      */
-    @Transactional
+    @Transactional(rollbackFor = Exception.class)
     @CacheEvict(value = {"material:categories", "material:subcategories"}, allEntries = true)
     public void deleteCategory(Integer categoryId) {
         logger.info("删除分类: categoryId={}", categoryId);
@@ -634,7 +654,7 @@ material.setCategoryId(categoryId);
         MaterialCategory category = categoryMapper.selectById(categoryId);
         if (category == null) {
             logger.warn("未找到指定分类: categoryId={}", categoryId);
-            throw new RuntimeException("指定的分类不存在");
+            throw new BusinessException(ErrorCode.NOT_FOUND, "指定的分类不存在");
         }
 
         // 获取该分类下的所有子分类
@@ -693,8 +713,8 @@ material.setCategoryId(categoryId);
      * 使用MyBatis-Plus的deleteById方法
      * @param subcategoryId 子分类ID
      */
-    @Transactional
-    @CacheEvict(value = "material:subcategories", allEntries = true)
+    @Transactional(rollbackFor = Exception.class)
+    @CacheEvict(value = {"material:categories", "material:subcategories"}, allEntries = true)
     public void deleteSubcategory(Integer subcategoryId) {
         logger.info("删除子分类: subcategoryId={}", subcategoryId);
 
@@ -705,14 +725,40 @@ material.setCategoryId(categoryId);
         MaterialSubcategory subcategory = subcategoryMapper.selectById(subcategoryId);
         if (subcategory == null) {
             logger.warn("未找到指定子分类: subcategoryId={}", subcategoryId);
-            throw new RuntimeException("指定的子分类不存在");
+            throw new BusinessException(ErrorCode.NOT_FOUND, "指定的子分类不存在");
         }
 
-        // 删除该子分类下的所有资料
+        // 批量获取该子分类下的所有资料
         List<Material> materials = materialMapper.findBySubcategoryId(subcategoryId);
-        for (Material material : materials) {
-            deleteMaterialFile(material.getFileUrl());
-            materialMapper.deleteById(material.getMaterialId());
+        
+        if (!materials.isEmpty()) {
+            // 批量获取 OSS 文件路径
+            List<String> ossPaths = materials.stream()
+                .map(Material::getFileUrl)
+                .filter(Objects::nonNull)
+                .filter(p -> !p.isEmpty())
+                .map(this::extractOssFilePath)
+                .filter(Objects::nonNull)
+                .toList();
+
+            // 批量删除 OSS 文件
+            if (!ossPaths.isEmpty() && ossUtil != null) {
+                try {
+                    for (String path : ossPaths) {
+                        ossUtil.deleteFile(path);
+                    }
+                    logger.info("批量删除 OSS 文件成功，数量：{}", ossPaths.size());
+                } catch (Exception e) {
+                    logger.warn("批量删除 OSS 文件部分失败：{}", e.getMessage());
+                }
+            }
+
+            // 批量删除资料记录
+            List<Integer> materialIds = materials.stream()
+                .map(Material::getMaterialId)
+                .toList();
+            materialMapper.deleteBatchIds(materialIds);
+            logger.info("批量删除资料记录成功，数量：{}", materialIds.size());
         }
 
         // 删除子分类记录

--- a/src/main/java/com/redmoon2333/service/PastActivityService.java
+++ b/src/main/java/com/redmoon2333/service/PastActivityService.java
@@ -9,6 +9,8 @@ import com.redmoon2333.entity.PastActivity;
 import com.redmoon2333.exception.BusinessException;
 import com.redmoon2333.exception.ErrorCode;
 import com.redmoon2333.mapper.PastActivityMapper;
+import com.redmoon2333.util.LocalFileUtil;
+import com.redmoon2333.util.PermissionUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,13 +26,18 @@ import java.util.List;
  * 往届活动服务
  */
 @Service
-@Transactional
 public class PastActivityService {
     
     private static final Logger logger = LoggerFactory.getLogger(PastActivityService.class);
     
     @Autowired
     private PastActivityMapper pastActivityMapper;
+    
+    @Autowired
+    private PermissionUtil permissionUtil;
+    
+    @Autowired
+    private LocalFileUtil localFileUtil;
     
     @org.springframework.beans.factory.annotation.Value("${file.base-url:http://localhost:8080}")
     private String fileBaseUrl;
@@ -128,6 +135,7 @@ public class PastActivityService {
      * @param request 往届活动请求
      * @return 创建的往届活动
      */
+    @Transactional(rollbackFor = Exception.class)
     public PastActivityResponse createPastActivity(PastActivityRequest request) {
         logger.info("创建往届活动 - 标题: {}", request.getTitle());
         logger.info("请求参数详情 - coverImage: {}, pushUrl: {}, year: {}", 
@@ -178,6 +186,7 @@ public class PastActivityService {
      * @param request 更新请求
      * @return 更新后的往届活动
      */
+    @Transactional(rollbackFor = Exception.class)
     public PastActivityResponse updatePastActivity(Integer pastActivityId, PastActivityRequest request) {
         logger.info("更新往届活动 - ID: {}", pastActivityId);
         
@@ -231,10 +240,14 @@ public class PastActivityService {
      * 删除往届活动
      * @param pastActivityId 往届活动ID
      */
+    @Transactional(rollbackFor = Exception.class)
     public void deletePastActivity(Integer pastActivityId) {
         logger.info("删除往届活动 - ID: {}", pastActivityId);
         
         try {
+            // 检查权限（部长/副部长）
+            permissionUtil.checkMinisterPermission();
+            
             // 参数校验
             if (pastActivityId == null || pastActivityId <= 0) {
                 throw new BusinessException(ErrorCode.INVALID_REQUEST_PARAMETER, "往届活动ID不能为空且必须大于0");
@@ -243,6 +256,18 @@ public class PastActivityService {
             PastActivity existingActivity = pastActivityMapper.selectById(pastActivityId);
             if (existingActivity == null) {
                 throw new BusinessException(ErrorCode.NOT_FOUND, "往届活动不存在");
+            }
+            
+            // 删除封面图片本地文件（如果有）
+            String coverImage = existingActivity.getCoverImage();
+            if (coverImage != null && !coverImage.isEmpty()) {
+                try {
+                    localFileUtil.deleteFile(coverImage);
+                    logger.info("封面图片本地文件删除成功: {}", coverImage);
+                } catch (Exception e) {
+                    logger.warn("删除封面图片本地文件失败: {}", coverImage, e);
+                    // 继续删除数据库记录，不阻断流程
+                }
             }
             
             int result = pastActivityMapper.deleteById(pastActivityId);

--- a/src/main/java/com/redmoon2333/service/UserService.java
+++ b/src/main/java/com/redmoon2333/service/UserService.java
@@ -312,8 +312,8 @@ public class UserService {
      */
     public int getUserCount() {
         try {
-            List<User> users = userMapper.selectList(null);
-            return users.size();
+            Long count = userMapper.selectCount(null);
+            return count != null ? count.intValue() : 0;
         } catch (Exception e) {
             logger.error("获取用户总数时发生异常", e);
             return 0;

--- a/src/main/java/com/redmoon2333/util/OssUtil.java
+++ b/src/main/java/com/redmoon2333/util/OssUtil.java
@@ -3,12 +3,14 @@ package com.redmoon2333.util;
 import com.aliyun.oss.OSS;
 import com.aliyun.oss.OSSClientBuilder;
 import com.aliyun.oss.model.GeneratePresignedUrlRequest;
+import com.aliyun.oss.model.OSSObject;
 import com.aliyun.oss.model.PutObjectRequest;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.util.Date;
 import java.util.UUID;
@@ -248,6 +250,40 @@ public class OssUtil {
         logger.debug("构建文件URL: {}", fileUrl);
         return fileUrl;
     }
-    
+
+    /**
+     * 通过 OSS SDK 直接获取文件流（服务端代理下载，绕过浏览器 Origin/Referer 策略）
+     * @param filePath 文件路径
+     * @return OSSObject 包含文件流和元数据
+     */
+    public OSSObject getFileStream(String filePath) {
+        logger.info("通过OSS SDK获取文件流: {}", filePath);
+
+        if (ossClient == null) {
+            tryCreateOssClient();
+        }
+
+        if (ossClient == null) {
+            String errorMessage = String.format(
+                "OSS客户端未配置或创建失败。配置检查: endpoint=%s, accessKeyId=%s, accessKeySecret=%s, bucketName=%s。",
+                endpoint != null ? endpoint : "未配置",
+                accessKeyId != null ? maskSensitiveInfo(accessKeyId) : "未配置",
+                accessKeySecret != null ? maskSensitiveInfo(accessKeySecret) : "未配置",
+                bucketName != null ? bucketName : "未配置"
+            );
+            logger.error(errorMessage);
+            throw new IllegalStateException(errorMessage);
+        }
+
+        try {
+            OSSObject ossObject = ossClient.getObject(bucketName, filePath);
+            logger.info("OSS文件流获取成功: {}, 大小: {}", filePath, ossObject.getObjectMetadata().getContentLength());
+            return ossObject;
+        } catch (Exception e) {
+            logger.error("OSS文件流获取失败: {}", filePath, e);
+            throw new RuntimeException("文件获取失败: " + e.getMessage(), e);
+        }
+    }
+
     // OSS客户端由配置类管理，无需手动关闭
 }

--- a/src/main/resources/mapper/MaterialMapper.xml
+++ b/src/main/resources/mapper/MaterialMapper.xml
@@ -61,8 +61,16 @@
         ORDER BY upload_time DESC
     </select>
 
-    <!-- 根据资料名称模糊查询 -->
+    <!-- 根据资料名称模糊查询（包含） -->
     <select id="findByNameLike" parameterType="java.lang.String" resultMap="BaseResultMap">
+        SELECT <include refid="Base_Column_List"/>
+        FROM material
+        WHERE material_name LIKE CONCAT('%', #{materialName}, '%')
+        ORDER BY upload_time DESC
+    </select>
+
+    <!-- 根据资料名称模糊查询（包含，findByNameContaining 别名） -->
+    <select id="findByNameContaining" parameterType="java.lang.String" resultMap="BaseResultMap">
         SELECT <include refid="Base_Column_List"/>
         FROM material
         WHERE material_name LIKE CONCAT('%', #{materialName}, '%')


### PR DESCRIPTION
- 使用统一API接口获取和删除活动图片，优化前端代码
- 活动服务中添加直接清除活动图片缓存方法，避免自调用缓存失效问题
- 删除活动图片时先删除数据库记录，再删除本地文件，确保数据一致性
- 添加事务管理，保证活动相关图片操作的原子性和数据安全
- 前端增加活动图片删除成功后自动刷新图片列表功能
- 日常图片管理新增批量删除功能，支持多选和批量删除提示
- 日常图片删除逻辑调整，先校验图片存在性，删除本地文件后删除数据库记录
- 日常图片批量删除时批量删除本地文件及数据库记录，增强效率与一致性
- 资料模块增加服务端代理下载功能，绕过OSS Referer限制并记录下载次数
- 资料服务中统一异常处理改为抛出业务异常，增强异常信息传递
- 资料分类及子分类操作增加冲突检测，抛出详细业务异常提示
- 前端用户状态检查增强，若token失效则退出登录并重定向至登录页面
- Http工具中统一处理401状态，自动退出登录并跳转登录页
- OSS控制器新增资料下载代理接口，解决跨域及Referer限制问题
- MetaObjectHandler新增uploadTime自动填充支持
- 完善异常类BusinessException新增构造方法支持异常链传递
- 前端素材下载实现通过动态创建链接实现文件下载，提升兼容性与用户体验
- 修改资料列表中的删除按钮样式，增强危险操作视觉提示
- 优化MaterialMapper，新增模糊查询别名，方便灵活查询使用